### PR TITLE
composer.json: Removed laminas/laminas-dependency-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,9 @@
     "require": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-servicemanager": "^3.10",
-        "laminas/laminas-cache": "^3.1",
-        "laminas/laminas-dependency-plugin": "^2.2"
+        "laminas/laminas-cache-storage-adapter-filesystem": "^2.3",
+        "laminas/laminas-cache-storage-adapter-session": "^2.4",
+        "laminas/laminas-cache-storage-adapter-memory": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
**Note**:
* [laminas/laminas-cache](https://github.com/laminas/laminas-cache) can no longer be required directly - instead, an adapter needs to install it (See [this comment](https://github.com/laminas/laminas-cache/issues/189#issuecomment-1002744621))
* Therefore, I added the 3 most common adapters: FileSystem, Session and Memory - @arhimede please confirm we're good to go with these, or if I need add/remove some